### PR TITLE
Add a Clear button to the Encoded Token box

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,9 @@
             <button type="button" class="btn btn-outline-secondary btn-md btn-copy" data-target="encodedjwt" title='copy to clipboard'>
               <span class="oi oi-clipboard"></span>
             </button>
+            <button type="button" class="btn btn-outline-secondary btn-md btn-clear" title='clear'>
+              <span class="oi oi-trash"></span>
+            </button>
           </p>
           <textarea rows=12 cols=34 id='encodedjwt' class='rawvalue'></textarea>
         </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -398,6 +398,11 @@ function getPublicKey(header, options) {
     .then(keystore => keystore.get(header));
 }
 
+function clearJwt(_event) {
+  editors.encodedjwt.setValue('');
+  editors.encodedjwt.save();
+}
+
 function copyToClipboard(_event) {
   const $elt = $(this),
       sourceElement = $elt.data('target'),
@@ -1685,6 +1690,7 @@ function parseAndDisplayToken(token) {
 $(document).ready(function() {
   $( '#version_id').text(BUILD_VERSION);
   $( '.btn-copy' ).on('click', copyToClipboard);
+  $( '.btn-clear' ).on('click', clearJwt);
   $( '.btn-encode' ).on('click', encodeJwt);
   $( '.btn-decode' ).on('click', showDecoded);
   $( '.btn-verify' ).on('click', verifyJwt);

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -223,7 +223,7 @@ pre.CodeMirror-line > span {
   z-index: 10;
 }
 
-.btn-copy, .btn-newkey, .btn-newpayload, .btn-newheader {
+.btn-copy, .btn-clear, .btn-newkey, .btn-newpayload, .btn-newheader {
   padding: 2px 6px;
   margin: 0 4px;
   float: right;


### PR DESCRIPTION
Add a Clear button to the left hand pane (Encoded Token).

When pasting on Linux using the highlight to copy it's inconvenient to highlight the existing content (overwriting my copy buffer), delete it, go highlight the JWT that I'm interested in and paste it.  This button makes that workflow easy.

The new button is to the left of the existing "Copy" button, which matches the style of the other entry fields (which have the copy button in the right most spot):
![image](https://github.com/DinoChiesa/jwt-webtool/assets/13788462/269f429e-4d84-42d1-a31d-92f14fc495bb)
